### PR TITLE
Empty allowed lists

### DIFF
--- a/include/waflz/profile.h
+++ b/include/waflz/profile.h
@@ -66,7 +66,7 @@ public:
         profile(engine &a_engine, geoip2_mmdb &a_geoip2_mmdb);
         ~profile();
         int32_t process(waflz_pb::event **ao_event, void *a_ctx);
-        int32_t load_config(const char *a_buf, uint32_t a_buf_len, bool a_leave_compiled_file = false);
+        int32_t load_config(const char *a_buf, uint32_t a_buf_len, geoip2_mmdb &a_geoip2_mmdb, bool a_leave_compiled_file = false);
         int32_t load_config(const waflz_pb::profile *a_pb, bool a_leave_compiled_file = false);
         //: ------------------------------------------------
         //:               G E T T E R S

--- a/include/waflz/profile.h
+++ b/include/waflz/profile.h
@@ -66,7 +66,7 @@ public:
         profile(engine &a_engine, geoip2_mmdb &a_geoip2_mmdb);
         ~profile();
         int32_t process(waflz_pb::event **ao_event, void *a_ctx);
-        int32_t load_config(const char *a_buf, uint32_t a_buf_len, geoip2_mmdb &a_geoip2_mmdb, bool a_leave_compiled_file = false);
+        int32_t load_config(const char *a_buf, uint32_t a_buf_len, bool a_leave_compiled_file = false);
         int32_t load_config(const waflz_pb::profile *a_pb, bool a_leave_compiled_file = false);
         //: ------------------------------------------------
         //:               G E T T E R S
@@ -115,6 +115,7 @@ private:
         waflz_pb::profile *m_pb;
         char m_err_msg[WAFLZ_ERR_LEN];
         engine &m_engine;
+        geoip2_mmdb &m_geoip2_mmdb;
         // -------------------------------------------------
         // engines...
         // -------------------------------------------------

--- a/src/core/profile.cc
+++ b/src/core/profile.cc
@@ -126,6 +126,7 @@ void profile::set_pb(waflz_pb::profile *a_pb)
 //: ----------------------------------------------------------------------------
 int32_t profile::load_config(const char *a_buf,
                              uint32_t a_buf_len,
+                             geoip2_mmdb &a_geoip2_mmdb,
                              bool a_leave_compiled_file)
 {
         if(a_buf_len > CONFIG_SECURITY_WAF_PROFILE_MAX_SIZE)
@@ -142,13 +143,19 @@ int32_t profile::load_config(const char *a_buf,
                 delete m_pb;
                 m_pb = NULL;
         }
+        if(m_acl)
+        {
+                delete m_acl;
+                m_acl = NULL;
+        }
+        m_acl = new acl(a_geoip2_mmdb);
         // -------------------------------------------------
         // load from json
         // -------------------------------------------------
         m_pb = new waflz_pb::profile();
         int32_t l_s;
         l_s = update_from_json(*m_pb, a_buf, a_buf_len);
-        //TRC_DEBUG("whole config %s", m_pb->DebugString().c_str());
+        //NDBG_PRINT("whole config %s", m_pb->DebugString().c_str());
         if(l_s != JSPB_OK)
         {
                 WAFLZ_PERROR(m_err_msg, "parsing json. reason: %s", get_err_msg());
@@ -491,21 +498,6 @@ int32_t profile::validate(void)
         VERIFY_HAS(l_gs, total_arg_length);
         VERIFY_HAS(l_gs, max_file_size);
         VERIFY_HAS(l_gs, combined_file_sizes);
-        if(!l_gs.allowed_http_methods_size())
-        {
-                WAFLZ_PERROR(m_err_msg, "missing %s field", "allowed_http_methods");
-                return WAFLZ_STATUS_ERROR;
-        }
-        if(!l_gs.allowed_request_content_types_size())
-        {
-                WAFLZ_PERROR(m_err_msg, "missing %s field", "allowed_request_content_types");
-                return WAFLZ_STATUS_ERROR;
-        }
-        if(!l_gs.allowed_http_methods_size())
-        {
-                WAFLZ_PERROR(m_err_msg, "missing %s field", "allowed_http_methods");
-                return WAFLZ_STATUS_ERROR;
-        }
         // set...
         if(l_gs.has_response_header_name())
         {

--- a/src/core/profile.cc
+++ b/src/core/profile.cc
@@ -81,6 +81,7 @@ profile::profile(engine &a_engine,
         m_pb(NULL),
         m_err_msg(),
         m_engine(a_engine),
+        m_geoip2_mmdb(a_geoip2_mmdb),
         m_acl(NULL),
         m_waf(NULL),
         m_id(),
@@ -126,7 +127,6 @@ void profile::set_pb(waflz_pb::profile *a_pb)
 //: ----------------------------------------------------------------------------
 int32_t profile::load_config(const char *a_buf,
                              uint32_t a_buf_len,
-                             geoip2_mmdb &a_geoip2_mmdb,
                              bool a_leave_compiled_file)
 {
         if(a_buf_len > CONFIG_SECURITY_WAF_PROFILE_MAX_SIZE)
@@ -148,7 +148,7 @@ int32_t profile::load_config(const char *a_buf,
                 delete m_acl;
                 m_acl = NULL;
         }
-        m_acl = new acl(a_geoip2_mmdb);
+        m_acl = new acl(m_geoip2_mmdb);
         // -------------------------------------------------
         // load from json
         // -------------------------------------------------

--- a/src/core/waf.cc
+++ b/src/core/waf.cc
@@ -902,11 +902,6 @@ int32_t waf::init(profile &a_profile, bool a_leave_tmp_file)
         // allowed http methods
         // -------------------------------------------------
         std::string l_alw_mth;
-        if(!l_gs.allowed_http_methods_size())
-        {
-                WAFLZ_PERROR(m_err_msg, "No allowed http methods provided.  Would block all traffic.  Not applying.");
-                return WAFLZ_STATUS_ERROR;
-        }
         for(int32_t i_ahm = 0; i_ahm < l_gs.allowed_http_methods_size(); ++i_ahm)
         {
                 // for each allowed http method
@@ -921,11 +916,6 @@ int32_t waf::init(profile &a_profile, bool a_leave_tmp_file)
         // -------------------------------------------------
         // allowed_request_content_types
         // -------------------------------------------------
-        if(!l_gs.allowed_request_content_types_size())
-        {
-                WAFLZ_PERROR(m_err_msg, "No allowed http request content-types provided.  Could block all traffic.  Not applying.");
-                return WAFLZ_STATUS_ERROR;
-        }
         std::string l_alw_rct;
         for(int32_t i_arct = 0; i_arct < l_gs.allowed_request_content_types_size(); ++i_arct)
         {

--- a/tests/blackbox/access_settings/test_bb_access_settings.py
+++ b/tests/blackbox/access_settings/test_bb_access_settings.py
@@ -232,6 +232,9 @@ def test_bb_modsec_ec_access_settings_10_bypass_empty_allowed_settings():
     l_r = requests.post(l_url,
                             headers=l_headers,
                             data=json.dumps(l_conf))
+    # ------------------------------------------------------
+    # test empty method and content type list is allowed
+    # ------------------------------------------------------
     assert l_r.status_code == 200
     # ------------------------------------------------------
     # test method and content is bypassed
@@ -242,6 +245,5 @@ def test_bb_modsec_ec_access_settings_10_bypass_empty_allowed_settings():
     l_r = requests.put(l_uri, headers=l_headers)
     assert l_r.status_code == 200
     l_r_json = l_r.json()
-    print l_r_json
     assert len(l_r_json) == 0
     teardown_func()

--- a/tests/blackbox/access_settings/test_bb_access_settings.py
+++ b/tests/blackbox/access_settings/test_bb_access_settings.py
@@ -203,4 +203,45 @@ def test_bb_modsec_ec_access_settings_09_block_disallowed_http_method():
     l_r_json = l_r.json()
     assert len(l_r_json) > 0
     assert 'Method is not allowed by policy' in l_r_json['rule_msg']
+# ------------------------------------------------------------------------------
+# test_bb_modsec_ec_access_settings_10_bypass_empty_allowed_settings
+# ------------------------------------------------------------------------------
+def test_bb_modsec_ec_access_settings_10_bypass_empty_allowed_settings():
+    l_uri = G_TEST_HOST
+    # ------------------------------------------------------
+    # update template
+    # ------------------------------------------------------
+    l_file_path = os.path.dirname(os.path.abspath(__file__))
+    l_conf = {}
+    l_conf_path = os.path.realpath(os.path.join(l_file_path, 'test_bb_access_settings.waf.prof.json'))
+    try:
+        with open(l_conf_path) as l_f:
+            l_conf = json.load(l_f)
+    except Exception as l_e:
+        print 'error opening config file: %s.  Reason: %s error: %s, doc: %s, message: %s'%(
+            l_conf_path, type(l_e), l_e, l_e.__doc__, l_e.message)
+        assert False
+    l_conf['general_settings']['allowed_request_content_types'] = []
+    l_conf['general_settings']['allowed_http_methods'] = []
+    l_url = '%supdate_profile'%(G_TEST_HOST)
+    # ------------------------------------------------------
+    # urlopen (POST)
+    # ------------------------------------------------------
+    print l_url
+    l_headers = {"Content-Type": "application/json"}
+    l_r = requests.post(l_url,
+                            headers=l_headers,
+                            data=json.dumps(l_conf))
+    assert l_r.status_code == 200
+    # ------------------------------------------------------
+    # test method and content is bypassed
+    # ------------------------------------------------------
+    l_headers = {"host" : "myhost.com",
+                 "Content-Type" : "select * from banana"
+                }
+    l_r = requests.put(l_uri, headers=l_headers)
+    assert l_r.status_code == 200
+    l_r_json = l_r.json()
+    print l_r_json
+    assert len(l_r_json) == 0
     teardown_func()

--- a/util/waflz_server/waflz_server.cc
+++ b/util/waflz_server/waflz_server.cc
@@ -105,8 +105,7 @@ class waflz_update_profile_h: public ns_is2::default_rqst_h
 public:
         waflz_update_profile_h():
                 default_rqst_h(),
-                m_profile(NULL),
-                m_geoip2_mmdb(NULL)
+                m_profile(NULL)
         {}
         ~waflz_update_profile_h()
         {}
@@ -139,7 +138,7 @@ ns_is2::h_resp_t waflz_update_profile_h::do_post(ns_is2::session &a_session,
         // TODO get status
         //ns_is2::mem_display((const uint8_t *)l_buf, (uint32_t)l_buf_len);
         int32_t l_s;
-        l_s = m_profile->load_config(l_buf, l_buf_len, *m_geoip2_mmdb, true);
+        l_s = m_profile->load_config(l_buf, l_buf_len, true);
         if(l_s != WAFLZ_STATUS_OK)
         {
                 TRC_ERROR("performing m_profile->load_config\n");
@@ -1743,9 +1742,8 @@ int main(int argc, char** argv)
                 l_waflz_h->m_profile = l_profile;
                 l_waflz_update_profile_h = new waflz_update_profile_h();
                 l_waflz_update_profile_h->m_profile = l_profile;
-                l_waflz_update_profile_h->m_geoip2_mmdb = l_geoip2_mmdb;
                 //NDBG_PRINT("load profile: %s\n", l_profile_file.c_str());
-                l_s = l_profile->load_config(l_buf, l_buf_len, *l_geoip2_mmdb, true);
+                l_s = l_profile->load_config(l_buf, l_buf_len, true);
                 if(l_s != WAFLZ_STATUS_OK)
                 {
                         NDBG_PRINT("error loading config: %s. reason: %s\n",

--- a/util/waflz_server/waflz_server.cc
+++ b/util/waflz_server/waflz_server.cc
@@ -105,7 +105,8 @@ class waflz_update_profile_h: public ns_is2::default_rqst_h
 public:
         waflz_update_profile_h():
                 default_rqst_h(),
-                m_profile(NULL)
+                m_profile(NULL),
+                m_geoip2_mmdb(NULL)
         {}
         ~waflz_update_profile_h()
         {}
@@ -113,6 +114,7 @@ public:
                                  ns_is2::rqst &a_rqst,
                                  const ns_is2::url_pmap_t &a_url_pmap);
         ns_waflz::profile *m_profile;
+        ns_waflz::geoip2_mmdb *m_geoip2_mmdb;
 };
 //: ----------------------------------------------------------------------------
 //: \details: TODO
@@ -137,7 +139,7 @@ ns_is2::h_resp_t waflz_update_profile_h::do_post(ns_is2::session &a_session,
         // TODO get status
         //ns_is2::mem_display((const uint8_t *)l_buf, (uint32_t)l_buf_len);
         int32_t l_s;
-        l_s = m_profile->load_config(l_buf, l_buf_len, true);
+        l_s = m_profile->load_config(l_buf, l_buf_len, *m_geoip2_mmdb, true);
         if(l_s != WAFLZ_STATUS_OK)
         {
                 TRC_ERROR("performing m_profile->load_config\n");
@@ -1741,8 +1743,9 @@ int main(int argc, char** argv)
                 l_waflz_h->m_profile = l_profile;
                 l_waflz_update_profile_h = new waflz_update_profile_h();
                 l_waflz_update_profile_h->m_profile = l_profile;
+                l_waflz_update_profile_h->m_geoip2_mmdb = l_geoip2_mmdb;
                 //NDBG_PRINT("load profile: %s\n", l_profile_file.c_str());
-                l_s = l_profile->load_config(l_buf, l_buf_len, true);
+                l_s = l_profile->load_config(l_buf, l_buf_len, *l_geoip2_mmdb, true);
                 if(l_s != WAFLZ_STATUS_OK)
                 {
                         NDBG_PRINT("error loading config: %s. reason: %s\n",

--- a/util/wjc/wjc.cc
+++ b/util/wjc/wjc.cc
@@ -325,6 +325,7 @@ int main(int argc, char** argv)
                 //NDBG_PRINT("Validate\n");
                 l_s = l_profile->load_config(l_config_buf,
                                              l_config_buf_len,
+                                             *l_geoip2_mmdb,
                                              (g_cleanup_tmp_files == 0));
                 if(l_s != WAFLZ_STATUS_OK)
                 {

--- a/util/wjc/wjc.cc
+++ b/util/wjc/wjc.cc
@@ -325,7 +325,6 @@ int main(int argc, char** argv)
                 //NDBG_PRINT("Validate\n");
                 l_s = l_profile->load_config(l_config_buf,
                                              l_config_buf_len,
-                                             *l_geoip2_mmdb,
                                              (g_cleanup_tmp_files == 0));
                 if(l_s != WAFLZ_STATUS_OK)
                 {


### PR DESCRIPTION
allowing empty allowed_method/content_type lists. 
Updating load_config endpoint to re instantiate acls everytime profile is updated.
No need to update instance.cc endpoint since it creates a new profile object every time