### PR TITLE
Bug fix op

### DIFF
--- a/src/core/tx.cc
+++ b/src/core/tx.cc
@@ -252,8 +252,7 @@ TX(LOWERCASE)
         // -------------------------------------------------
         char *l_buf = (char *)malloc(sizeof(char)*a_len + 1);
         l_buf[a_len] = '\0';
-        ao_len = a_len;
-        for(uint32_t i_idx = 0; i_idx < ao_len; ++i_idx)
+        for(uint32_t i_idx = 0; i_idx < a_len; ++i_idx)
         {
                 l_buf[i_idx] = tolower((int)a_buf[i_idx]);
         }

--- a/src/core/tx.cc
+++ b/src/core/tx.cc
@@ -250,12 +250,15 @@ TX(LOWERCASE)
         // -------------------------------------------------
         // transform...
         // -------------------------------------------------
-        *ao_buf = (char *)malloc(sizeof(char)*a_len);
+        char *l_buf = (char *)malloc(sizeof(char)*a_len + 1);
+        l_buf[a_len] = '\0';
         ao_len = a_len;
         for(uint32_t i_idx = 0; i_idx < ao_len; ++i_idx)
         {
-                (*ao_buf)[i_idx] = tolower((int)a_buf[i_idx]);
+                l_buf[i_idx] = tolower((int)a_buf[i_idx]);
         }
+        *ao_buf = l_buf;
+        ao_len = a_len;
         return WAFLZ_STATUS_OK;
 }
 //: ----------------------------------------------------------------------------


### PR DESCRIPTION
- allocation of memory to pointer to pointer was wrong, in such a case memory needs to be allocated 2 dimensional. This was causing a heap overflow when the pointer was dereferenced. Adding a simpler and cleaner way of handling this. 