### PR TITLE
Changing the docker CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,12 @@ COPY . /opt/waflz
 
 RUN cd /opt/waflz && \
      pip install -r requirements.txt && \
-     ./build.sh && \
-     echo "SecRule ARGS:x \"@streq test\" \"deny,status:403,id:123\"" > test.conf
+     ./build.sh
 
 EXPOSE 12345
 
-CMD ["/opt/waflz/build/util/waflz_server/waflz_server --conf-file=/opt/waflz/test.conf"]
+CMD ["/opt/waflz/build/util/waflz_server/waflz_server", \
+  "--ruleset-dir=/opt/waflz/tests/data/waf/ruleset", \
+  "--geoip-db=/opt/waflz/tests/data/waf/db/GeoLite2-City.mmdb", \
+  "-geoip-isp-db=/opt/waflz/tests/data/waf/db/GeoLite2-ASN.mmdb", \
+  "--profile=/opt/waflz/tests/blackbox/ruleset/template.waf.prof.json"]


### PR DESCRIPTION
This seems to work pretty well. 

A couple notes, the suggestion to make a bogus max mind didn't seem to work, I needed to provide. Also, i'm not sure how to really use the `--modsecurity` flag in bulk :), otherwise i'll need to convert the CRS 3.x rules to the JSON format, not sure if you guys have a tool for that (maybe waflz_dump). Great work!

```
docker build -t waflz .
docker run --rm -p80:12345 -it waflz 
```