### PR TITLE
Rapidjson gcc 8 updates

### DIFF
--- a/ext/rapidjson/allocators.h
+++ b/ext/rapidjson/allocators.h
@@ -53,7 +53,7 @@ concept Allocator {
 */
 
 
-/*! \def RAPIDJSON_ALLOCATOR_DEFUALT_CHUNK_CAPACITY
+/*! \def RAPIDJSON_ALLOCATOR_DEFAULT_CHUNK_CAPACITY
     \ingroup RAPIDJSON_CONFIG
     \brief User-defined kDefaultChunkCapacity definition.
 

--- a/ext/rapidjson/filereadstream.h
+++ b/ext/rapidjson/filereadstream.h
@@ -59,7 +59,7 @@ public:
 
     // For encoding detection only.
     const Ch* Peek4() const {
-        return (current_ + 4 <= bufferLast_) ? current_ : 0;
+        return (current_ + 4 - !eof_ <= bufferLast_) ? current_ : 0;
     }
 
 private:

--- a/ext/rapidjson/fwd.h
+++ b/ext/rapidjson/fwd.h
@@ -102,7 +102,7 @@ class PrettyWriter;
 // document.h
 
 template <typename Encoding, typename Allocator> 
-struct GenericMember;
+class GenericMember;
 
 template <bool Const, typename Encoding, typename Allocator>
 class GenericMemberIterator;

--- a/ext/rapidjson/internal/clzll.h
+++ b/ext/rapidjson/internal/clzll.h
@@ -1,0 +1,72 @@
+// Tencent is pleased to support the open source community by making RapidJSON available.
+//
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef RAPIDJSON_CLZLL_H_
+#define RAPIDJSON_CLZLL_H_
+
+#include "../rapidjson.h"
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#if defined(_WIN64)
+#pragma intrinsic(_BitScanReverse64)
+#else
+#pragma intrinsic(_BitScanReverse)
+#endif
+#endif
+
+RAPIDJSON_NAMESPACE_BEGIN
+namespace internal {
+
+#if (defined(__GNUC__) && __GNUC__ >= 4) || RAPIDJSON_HAS_BUILTIN(__builtin_clzll)
+#define RAPIDJSON_CLZLL __builtin_clzll
+#else
+
+inline uint32_t clzll(uint64_t x) {
+    // Passing 0 to __builtin_clzll is UB in GCC and results in an
+    // infinite loop in the software implementation.
+    RAPIDJSON_ASSERT(x != 0);
+
+#if defined(_MSC_VER)
+    unsigned long r = 0;
+#if defined(_WIN64)
+    _BitScanReverse64(&r, x);
+#else
+    // Scan the high 32 bits.
+    if (_BitScanReverse(&r, static_cast<uint32_t>(x >> 32)))
+        return 63 - (r + 32);
+
+    // Scan the low 32 bits.
+    _BitScanReverse(&r, static_cast<uint32_t>(x & 0xFFFFFFFF));
+#endif // _WIN64
+
+    return 63 - r;
+#else
+    uint32_t r;
+    while (!(x & (static_cast<uint64_t>(1) << 63))) {
+        x <<= 1;
+        ++r;
+    }
+
+    return r;
+#endif // _MSC_VER
+}
+
+#define RAPIDJSON_CLZLL RAPIDJSON_NAMESPACE::internal::clzll
+#endif // (defined(__GNUC__) && __GNUC__ >= 4) || RAPIDJSON_HAS_BUILTIN(__builtin_clzll)
+
+} // namespace internal
+RAPIDJSON_NAMESPACE_END
+
+#endif // RAPIDJSON_CLZLL_H_

--- a/ext/rapidjson/internal/diyfp.h
+++ b/ext/rapidjson/internal/diyfp.h
@@ -20,11 +20,11 @@
 #define RAPIDJSON_DIYFP_H_
 
 #include "../rapidjson.h"
+#include "clzll.h"
 #include <limits>
 
 #if defined(_MSC_VER) && defined(_M_AMD64) && !defined(__INTEL_COMPILER)
 #include <intrin.h>
-#pragma intrinsic(_BitScanReverse64)
 #pragma intrinsic(_umul128)
 #endif
 
@@ -100,22 +100,8 @@ struct DiyFp {
     }
 
     DiyFp Normalize() const {
-        RAPIDJSON_ASSERT(f != 0); // https://stackoverflow.com/a/26809183/291737
-#if defined(_MSC_VER) && defined(_M_AMD64)
-        unsigned long index;
-        _BitScanReverse64(&index, f);
-        return DiyFp(f << (63 - index), e - (63 - index));
-#elif defined(__GNUC__) && __GNUC__ >= 4
-        int s = __builtin_clzll(f);
+        int s = static_cast<int>(RAPIDJSON_CLZLL(f));
         return DiyFp(f << s, e - s);
-#else
-        DiyFp res = *this;
-        while (!(res.f & (static_cast<uint64_t>(1) << 63))) {
-            res.f <<= 1;
-            res.e--;
-        }
-        return res;
-#endif
     }
 
     DiyFp NormalizeBoundary() const {

--- a/ext/rapidjson/internal/regex.h
+++ b/ext/rapidjson/internal/regex.h
@@ -23,7 +23,6 @@
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(padded)
 RAPIDJSON_DIAG_OFF(switch-enum)
-RAPIDJSON_DIAG_OFF(implicit-fallthrough)
 #elif defined(_MSC_VER)
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4512) // assignment operator could not be generated
@@ -32,9 +31,6 @@ RAPIDJSON_DIAG_OFF(4512) // assignment operator could not be generated
 #ifdef __GNUC__
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(effc++)
-#if __GNUC__ >= 7
-RAPIDJSON_DIAG_OFF(implicit-fallthrough)
-#endif
 #endif
 
 #ifndef RAPIDJSON_REGEX_VERBOSE
@@ -118,7 +114,8 @@ public:
     template <typename, typename> friend class GenericRegexSearch;
 
     GenericRegex(const Ch* source, Allocator* allocator = 0) : 
-        states_(allocator, 256), ranges_(allocator, 256), root_(kRegexInvalidState), stateCount_(), rangeCount_(), 
+        ownAllocator_(allocator ? 0 : RAPIDJSON_NEW(Allocator)()), allocator_(allocator ? allocator : ownAllocator_), 
+        states_(allocator_, 256), ranges_(allocator_, 256), root_(kRegexInvalidState), stateCount_(), rangeCount_(), 
         anchorBegin_(), anchorEnd_()
     {
         GenericStringStream<Encoding> ss(source);
@@ -126,7 +123,10 @@ public:
         Parse(ds);
     }
 
-    ~GenericRegex() {}
+    ~GenericRegex()
+    {
+        RAPIDJSON_DELETE(ownAllocator_);
+    }
 
     bool IsValid() const {
         return root_ != kRegexInvalidState;
@@ -188,10 +188,9 @@ private:
 
     template <typename InputStream>
     void Parse(DecodedStream<InputStream, Encoding>& ds) {
-        Allocator allocator;
-        Stack<Allocator> operandStack(&allocator, 256);     // Frag
-        Stack<Allocator> operatorStack(&allocator, 256);    // Operator
-        Stack<Allocator> atomCountStack(&allocator, 256);   // unsigned (Atom per parenthesis)
+        Stack<Allocator> operandStack(allocator_, 256);    // Frag
+        Stack<Allocator> operatorStack(allocator_, 256);   // Operator
+        Stack<Allocator> atomCountStack(allocator_, 256);  // unsigned (Atom per parenthesis)
 
         *atomCountStack.template Push<unsigned>() = 0;
 
@@ -288,6 +287,7 @@ private:
                     if (!CharacterEscape(ds, &codepoint))
                         return; // Unsupported escape character
                     // fall through to default
+                    RAPIDJSON_DELIBERATE_FALLTHROUGH;
 
                 default: // Pattern character
                     PushOperand(operandStack, codepoint);
@@ -392,8 +392,7 @@ private:
                 }
                 return false;
 
-            default: 
-                RAPIDJSON_ASSERT(op == kOneOrMore);
+            case kOneOrMore:
                 if (operandStack.GetSize() >= sizeof(Frag)) {
                     Frag e = *operandStack.template Pop<Frag>(1);
                     SizeType s = NewState(kRegexInvalidState, e.start, 0);
@@ -401,6 +400,10 @@ private:
                     *operandStack.template Push<Frag>() = Frag(e.start, s, e.minIndex);
                     return true;
                 }
+                return false;
+
+            default: 
+                // syntax error (e.g. unclosed kLeftParenthesis)
                 return false;
         }
     }
@@ -514,6 +517,7 @@ private:
                 else if (!CharacterEscape(ds, &codepoint))
                     return false;
                 // fall through to default
+                RAPIDJSON_DELIBERATE_FALLTHROUGH;
 
             default:
                 switch (step) {
@@ -523,6 +527,7 @@ private:
                         break;
                     }
                     // fall through to step 0 for other characters
+                    RAPIDJSON_DELIBERATE_FALLTHROUGH;
 
                 case 0:
                     {
@@ -582,6 +587,8 @@ private:
         }
     }
 
+    Allocator* ownAllocator_;
+    Allocator* allocator_;
     Stack<Allocator> states_;
     Stack<Allocator> ranges_;
     SizeType root_;

--- a/ext/rapidjson/internal/stack.h
+++ b/ext/rapidjson/internal/stack.h
@@ -17,6 +17,7 @@
 
 #include "../allocators.h"
 #include "swap.h"
+#include <cstddef>
 
 #if defined(__clang__)
 RAPIDJSON_DIAG_PUSH
@@ -114,7 +115,7 @@ public:
     template<typename T>
     RAPIDJSON_FORCEINLINE void Reserve(size_t count = 1) {
          // Expand the stack if needed
-        if (RAPIDJSON_UNLIKELY(stackTop_ + sizeof(T) * count > stackEnd_))
+        if (RAPIDJSON_UNLIKELY(static_cast<std::ptrdiff_t>(sizeof(T) * count) > (stackEnd_ - stackTop_)))
             Expand<T>(count);
     }
 
@@ -127,7 +128,7 @@ public:
     template<typename T>
     RAPIDJSON_FORCEINLINE T* PushUnsafe(size_t count = 1) {
         RAPIDJSON_ASSERT(stackTop_);
-        RAPIDJSON_ASSERT(stackTop_ + sizeof(T) * count <= stackEnd_);
+        RAPIDJSON_ASSERT(static_cast<std::ptrdiff_t>(sizeof(T) * count) <= (stackEnd_ - stackTop_));
         T* ret = reinterpret_cast<T*>(stackTop_);
         stackTop_ += sizeof(T) * count;
         return ret;

--- a/ext/rapidjson/pointer.h
+++ b/ext/rapidjson/pointer.h
@@ -200,6 +200,36 @@ public:
         return *this;
     }
 
+    //! Swap the content of this pointer with an other.
+    /*!
+        \param other The pointer to swap with.
+        \note Constant complexity.
+    */
+    GenericPointer& Swap(GenericPointer& other) RAPIDJSON_NOEXCEPT {
+        internal::Swap(allocator_, other.allocator_);
+        internal::Swap(ownAllocator_, other.ownAllocator_);
+        internal::Swap(nameBuffer_, other.nameBuffer_);
+        internal::Swap(tokens_, other.tokens_);
+        internal::Swap(tokenCount_, other.tokenCount_);
+        internal::Swap(parseErrorOffset_, other.parseErrorOffset_);
+        internal::Swap(parseErrorCode_, other.parseErrorCode_);
+        return *this;
+    }
+
+    //! free-standing swap function helper
+    /*!
+        Helper function to enable support for common swap implementation pattern based on \c std::swap:
+        \code
+        void swap(MyClass& a, MyClass& b) {
+            using std::swap;
+            swap(a.pointer, b.pointer);
+            // ...
+        }
+        \endcode
+        \see Swap()
+     */
+    friend inline void swap(GenericPointer& a, GenericPointer& b) RAPIDJSON_NOEXCEPT { a.Swap(b); }
+
     //@}
 
     //!@name Append token
@@ -356,6 +386,33 @@ public:
     */
     bool operator!=(const GenericPointer& rhs) const { return !(*this == rhs); }
 
+    //! Less than operator.
+    /*!
+        \note Invalid pointers are always greater than valid ones.
+    */
+    bool operator<(const GenericPointer& rhs) const {
+        if (!IsValid())
+            return false;
+        if (!rhs.IsValid())
+            return true;
+
+        if (tokenCount_ != rhs.tokenCount_)
+            return tokenCount_ < rhs.tokenCount_;
+
+        for (size_t i = 0; i < tokenCount_; i++) {
+            if (tokens_[i].index != rhs.tokens_[i].index)
+                return tokens_[i].index < rhs.tokens_[i].index;
+
+            if (tokens_[i].length != rhs.tokens_[i].length)
+                return tokens_[i].length < rhs.tokens_[i].length;
+
+            if (int cmp = std::memcmp(tokens_[i].name, rhs.tokens_[i].name, sizeof(Ch) * tokens_[i].length))
+                return cmp < 0;
+        }
+
+        return false;
+    }
+
     //@}
 
     //!@name Stringify
@@ -431,10 +488,11 @@ public:
                     v = &((*v)[t->index]);
                 }
                 else {
-                    typename ValueType::MemberIterator m = v->FindMember(GenericStringRef<Ch>(t->name, t->length));
+                    typename ValueType::MemberIterator m = v->FindMember(GenericValue<EncodingType>(GenericStringRef<Ch>(t->name, t->length)));
                     if (m == v->MemberEnd()) {
                         v->AddMember(ValueType(t->name, t->length, allocator).Move(), ValueType().Move(), allocator);
-                        v = &(--v->MemberEnd())->value; // Assumes AddMember() appends at the end
+                        m = v->MemberEnd();
+                        v = &(--m)->value; // Assumes AddMember() appends at the end
                         exist = false;
                     }
                     else
@@ -486,7 +544,7 @@ public:
             switch (v->GetType()) {
             case kObjectType:
                 {
-                    typename ValueType::MemberIterator m = v->FindMember(GenericStringRef<Ch>(t->name, t->length));
+                    typename ValueType::MemberIterator m = v->FindMember(GenericValue<EncodingType>(GenericStringRef<Ch>(t->name, t->length)));
                     if (m == v->MemberEnd())
                         break;
                     v = &m->value;
@@ -722,7 +780,7 @@ public:
             switch (v->GetType()) {
             case kObjectType:
                 {
-                    typename ValueType::MemberIterator m = v->FindMember(GenericStringRef<Ch>(t->name, t->length));
+                    typename ValueType::MemberIterator m = v->FindMember(GenericValue<EncodingType>(GenericStringRef<Ch>(t->name, t->length)));
                     if (m == v->MemberEnd())
                         return false;
                     v = &m->value;

--- a/ext/rapidjson/rapidjson.h
+++ b/ext/rapidjson/rapidjson.h
@@ -490,6 +490,12 @@ RAPIDJSON_NAMESPACE_END
 #define RAPIDJSON_VERSION_CODE(x,y,z) \
   (((x)*100000) + ((y)*100) + (z))
 
+#if defined(__has_builtin)
+#define RAPIDJSON_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define RAPIDJSON_HAS_BUILTIN(x) 0
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_DIAG_PUSH/POP, RAPIDJSON_DIAG_OFF
 
@@ -591,7 +597,47 @@ RAPIDJSON_NAMESPACE_END
 #endif
 #endif // RAPIDJSON_HAS_CXX11_RANGE_FOR
 
+///////////////////////////////////////////////////////////////////////////////
+// C++17 features
+
+#if defined(__has_cpp_attribute)
+# if __has_cpp_attribute(fallthrough)
+#  define RAPIDJSON_DELIBERATE_FALLTHROUGH [[fallthrough]]
+# else
+#  define RAPIDJSON_DELIBERATE_FALLTHROUGH
+# endif
+#else
+# define RAPIDJSON_DELIBERATE_FALLTHROUGH
+#endif
+
 //!@endcond
+
+//! Assertion (in non-throwing contexts).
+ /*! \ingroup RAPIDJSON_CONFIG
+    Some functions provide a \c noexcept guarantee, if the compiler supports it.
+    In these cases, the \ref RAPIDJSON_ASSERT macro cannot be overridden to
+    throw an exception.  This macro adds a separate customization point for
+    such cases.
+
+    Defaults to C \c assert() (as \ref RAPIDJSON_ASSERT), if \c noexcept is
+    supported, and to \ref RAPIDJSON_ASSERT otherwise.
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+// RAPIDJSON_NOEXCEPT_ASSERT
+
+#ifndef RAPIDJSON_NOEXCEPT_ASSERT
+#ifdef RAPIDJSON_ASSERT_THROWS
+#if RAPIDJSON_HAS_CXX11_NOEXCEPT
+#define RAPIDJSON_NOEXCEPT_ASSERT(x)
+#else
+#include <cassert>
+#define RAPIDJSON_NOEXCEPT_ASSERT(x) assert(x)
+#endif // RAPIDJSON_HAS_CXX11_NOEXCEPT
+#else
+#define RAPIDJSON_NOEXCEPT_ASSERT(x) RAPIDJSON_ASSERT(x)
+#endif // RAPIDJSON_ASSERT_THROWS
+#endif // RAPIDJSON_NOEXCEPT_ASSERT
 
 ///////////////////////////////////////////////////////////////////////////////
 // new/delete

--- a/ext/rapidjson/writer.h
+++ b/ext/rapidjson/writer.h
@@ -16,6 +16,7 @@
 #define RAPIDJSON_WRITER_H_
 
 #include "stream.h"
+#include "internal/clzll.h"
 #include "internal/meta.h"
 #include "internal/stack.h"
 #include "internal/strfunc.h"
@@ -226,7 +227,7 @@ public:
       return Key(str.data(), SizeType(str.size()));
     }
 #endif
-	
+
     bool EndObject(SizeType memberCount = 0) {
         (void)memberCount;
         RAPIDJSON_ASSERT(level_stack_.GetSize() >= sizeof(Level)); // not inside an Object
@@ -460,8 +461,7 @@ protected:
         PutReserve(*os_, length);
         GenericStringStream<SourceEncoding> is(json);
         while (RAPIDJSON_LIKELY(is.Tell() < length)) {
-            const Ch c = is.Peek();
-            RAPIDJSON_ASSERT(c != '\0');
+            RAPIDJSON_ASSERT(is.Peek() != '\0');
             if (RAPIDJSON_UNLIKELY(!(writeFlags & kWriteValidateEncodingFlag ? 
                 Transcoder<SourceEncoding, TargetEncoding>::Validate(is, *os_) :
                 Transcoder<SourceEncoding, TargetEncoding>::TranscodeUnsafe(is, *os_))))
@@ -669,19 +669,19 @@ inline bool Writer<StringBuffer>::ScanWriteUnescapedString(StringStream& is, siz
         x = vorrq_u8(x, vcltq_u8(s, s3));
 
         x = vrev64q_u8(x);                     // Rev in 64
-        uint64_t low = vgetq_lane_u64(reinterpret_cast<uint64x2_t>(x), 0);   // extract
-        uint64_t high = vgetq_lane_u64(reinterpret_cast<uint64x2_t>(x), 1);  // extract
+        uint64_t low = vgetq_lane_u64(vreinterpretq_u64_u8(x), 0);   // extract
+        uint64_t high = vgetq_lane_u64(vreinterpretq_u64_u8(x), 1);  // extract
 
         SizeType len = 0;
         bool escaped = false;
         if (low == 0) {
             if (high != 0) {
-                unsigned lz = (unsigned)__builtin_clzll(high);
+                uint32_t lz = RAPIDJSON_CLZLL(high);
                 len = 8 + (lz >> 3);
                 escaped = true;
             }
         } else {
-            unsigned lz = (unsigned)__builtin_clzll(low);
+            uint32_t lz = RAPIDJSON_CLZLL(low);
             len = lz >> 3;
             escaped = true;
         }

--- a/src/core/instances.cc
+++ b/src/core/instances.cc
@@ -109,7 +109,7 @@ int32_t instances::load(instance **ao_instance, void *a_js, bool a_update)
         l_s = l_instance->load(a_js);
         if(l_s != WAFLZ_STATUS_OK)
         {
-                WAFLZ_AERROR(m_err_msg, "%s", l_instance->get_err_msg());
+                WAFLZ_PERROR(m_err_msg, "%s", l_instance->get_err_msg());
                 if(l_instance) { delete l_instance; l_instance = NULL;}
                 return WAFLZ_STATUS_ERROR;
         }

--- a/src/core/scopes_configs.cc
+++ b/src/core/scopes_configs.cc
@@ -296,7 +296,7 @@ int32_t scopes_configs::load(void* a_js)
         l_s = l_scopes->load(a_js, m_conf_dir);
         if(l_s != WAFLZ_STATUS_OK)
         {
-                WAFLZ_AERROR(m_err_msg, "%s", l_scopes->get_err_msg());
+                WAFLZ_PERROR(m_err_msg, "%s", l_scopes->get_err_msg());
                 if(l_scopes) { delete l_scopes; l_scopes = NULL;}
                 return WAFLZ_STATUS_ERROR;                
         }

--- a/src/parser/parser_json.cc
+++ b/src/parser/parser_json.cc
@@ -27,6 +27,7 @@
 #include "waflz/rqst_ctx.h"
 #include "parser/parser_json.h"
 #include "support/ndebug.h"
+#include "support/string_util.h"
 //: ----------------------------------------------------------------------------
 //: macros
 //: ----------------------------------------------------------------------------
@@ -83,51 +84,6 @@ int json_add_argument(arg_list_t &ao_arg_list,
         //NDBG_PRINT("ADD_ARG [%d]%.*s: [%d]%.*s\n", l_arg.m_key_len, l_arg.m_key_len, l_arg.m_key, l_arg.m_val_len, l_arg.m_val_len, l_arg.m_val);
         ao_arg_list.push_back(l_arg);
         return 1;
-}
-//: ----------------------------------------------------------------------------
-//: \details Appends src to string dst of size dsize
-//:          (unlike strncat, dsize is full size of dst, not space left).
-//:          At most dsize-1 characters will be copied.
-//:          Always NULL terminates (unless dsize <= strlen(dst)).
-//: \return  strlen(src) + MIN(dsize, strlen(initial dst)).
-//:          If retval >= dsize, truncation occurred.
-//: \param   TODO
-//: ----------------------------------------------------------------------------
-static size_t strlcat(char *a_dst, const char *a_src, size_t a_dsize)
-{
-        const char *l_odst = a_dst;
-        const char *l_osrc = a_src;
-        size_t l_n = a_dsize;
-        size_t l_dlen;
-        // -------------------------------------------------
-        // Find the end of a_dst and adjust bytes left but
-        /// don't go past end.
-        // -------------------------------------------------
-        while(l_n-- != 0 &&
-              *a_dst != '\0')
-        {
-                ++a_dst;
-        }
-        l_dlen = a_dst - l_odst;
-        l_n = a_dsize - l_dlen;
-        if (l_n-- == 0)
-        {
-                return(l_dlen + strlen(a_src));
-        }
-        while (*a_src != '\0')
-        {
-                if (l_n != 0)
-                {
-                        *a_dst++ = *a_src;
-                        l_n--;
-                }
-                ++a_src;
-        }
-        *a_dst = '\0';
-        // -------------------------------------------------
-        // count does not include NULL
-        // -------------------------------------------------
-        return(l_dlen + (a_src - l_osrc));
 }
 //: ----------------------------------------------------------------------------
 //: \details callback for hash a_key values; use to define var names under ARGS.

--- a/src/parser/parser_json.cc
+++ b/src/parser/parser_json.cc
@@ -197,7 +197,7 @@ static int yajl_start_map_cb(void *a_ctx)
                 }
                 if(l_max_cat_len)
                 {
-                        strncat((char *)l_parser->m_prefix, (char *)l_parser->m_current_key, l_max_cat_len);
+                       // strncat((char *)l_parser->m_prefix, (char *)l_parser->m_current_key, l_max_cat_len);
                 }
         }
         else

--- a/src/parser/parser_json.cc
+++ b/src/parser/parser_json.cc
@@ -85,6 +85,51 @@ int json_add_argument(arg_list_t &ao_arg_list,
         return 1;
 }
 //: ----------------------------------------------------------------------------
+//: \details Appends src to string dst of size dsize
+//:          (unlike strncat, dsize is full size of dst, not space left).
+//:          At most dsize-1 characters will be copied.
+//:          Always NULL terminates (unless dsize <= strlen(dst)).
+//: \return  strlen(src) + MIN(dsize, strlen(initial dst)).
+//:          If retval >= dsize, truncation occurred.
+//: \param   TODO
+//: ----------------------------------------------------------------------------
+static size_t strlcat(char *a_dst, const char *a_src, size_t a_dsize)
+{
+        const char *l_odst = a_dst;
+        const char *l_osrc = a_src;
+        size_t l_n = a_dsize;
+        size_t l_dlen;
+        // -------------------------------------------------
+        // Find the end of a_dst and adjust bytes left but
+        /// don't go past end.
+        // -------------------------------------------------
+        while(l_n-- != 0 &&
+              *a_dst != '\0')
+        {
+                ++a_dst;
+        }
+        l_dlen = a_dst - l_odst;
+        l_n = a_dsize - l_dlen;
+        if (l_n-- == 0)
+        {
+                return(l_dlen + strlen(a_src));
+        }
+        while (*a_src != '\0')
+        {
+                if (l_n != 0)
+                {
+                        *a_dst++ = *a_src;
+                        l_n--;
+                }
+                ++a_src;
+        }
+        *a_dst = '\0';
+        // -------------------------------------------------
+        // count does not include NULL
+        // -------------------------------------------------
+        return(l_dlen + (a_src - l_osrc));
+}
+//: ----------------------------------------------------------------------------
 //: \details callback for hash a_key values; use to define var names under ARGS.
 //:          if new a_key, update current a_key a_val.
 //: \return  TODO
@@ -192,12 +237,12 @@ static int yajl_start_map_cb(void *a_ctx)
                 l_max_cat_len = PARSER_JSON_PREFIX_LEN_MAX - l_prefix_len - 1;
                 if(l_max_cat_len)
                 {
-                        strncat((char *)l_parser->m_prefix, ".", l_max_cat_len);
+                        strlcat((char *)l_parser->m_prefix, ".", PARSER_JSON_PREFIX_LEN_MAX);
                         --l_max_cat_len;
                 }
                 if(l_max_cat_len)
                 {
-                       // strncat((char *)l_parser->m_prefix, (char *)l_parser->m_current_key, l_max_cat_len);
+                        strlcat((char *)l_parser->m_prefix, (char *)l_parser->m_current_key, PARSER_JSON_PREFIX_LEN_MAX);
                 }
         }
         else

--- a/src/support/string_util.cc
+++ b/src/support/string_util.cc
@@ -298,6 +298,51 @@ uint64_t strntoull(const char *a_str, size_t a_size, char **ao_end, int a_base)
         return l_ret;
 }
 //: ----------------------------------------------------------------------------
+//: \details Appends src to string dst of size dsize
+//:          (unlike strncat, dsize is full size of dst, not space left).
+//:          At most dsize-1 characters will be copied.
+//:          Always NULL terminates (unless dsize <= strlen(dst)).
+//: \return  strlen(src) + MIN(dsize, strlen(initial dst)).
+//:          If retval >= dsize, truncation occurred.
+//: \param   TODO
+//: ----------------------------------------------------------------------------
+size_t strlcat(char *a_dst, const char *a_src, size_t a_dsize)
+{
+        const char *l_odst = a_dst;
+        const char *l_osrc = a_src;
+        size_t l_n = a_dsize;
+        size_t l_dlen;
+        // -------------------------------------------------
+        // Find the end of a_dst and adjust bytes left but
+        /// don't go past end.
+        // -------------------------------------------------
+        while(l_n-- != 0 &&
+              *a_dst != '\0')
+        {
+                ++a_dst;
+        }
+        l_dlen = a_dst - l_odst;
+        l_n = a_dsize - l_dlen;
+        if (l_n-- == 0)
+        {
+                return(l_dlen + strlen(a_src));
+        }
+        while (*a_src != '\0')
+        {
+                if (l_n != 0)
+                {
+                        *a_dst++ = *a_src;
+                        l_n--;
+                }
+                ++a_src;
+        }
+        *a_dst = '\0';
+        // -------------------------------------------------
+        // count does not include NULL
+        // -------------------------------------------------
+        return(l_dlen + (a_src - l_osrc));
+}
+//: ----------------------------------------------------------------------------
 //: \details TODO
 //: \return  TODO
 //: \param   TODO

--- a/src/support/string_util.h
+++ b/src/support/string_util.h
@@ -43,6 +43,7 @@ long int strntol(const char *a_str, size_t a_size, char **ao_end, int a_base);
 int64_t strntoll(const char *a_str, size_t a_size, char **ao_end, int a_base);
 unsigned long int strntoul(const char *a_str, size_t a_size, char **ao_end, int a_base);
 uint64_t strntoull(const char *a_str, size_t a_size, char **ao_end, int a_base);
+size_t strlcat(char *a_dst, const char *a_src, size_t a_dsize);
 #if defined(__APPLE__) || defined(__darwin__)
 void * memrchr(const void *s, int c, size_t n);
 #endif


### PR DESCRIPTION
Updated rapidjson and added a `strlcat` impl to the json parser to do safer strcats to a fix sized buffer.
Adapted from:
http://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/src/lib/libc/string/strlcat.c
waflz should compile with gcc/g++ 8.x.