### PR TITLE
Custom rule setvar

### DIFF
--- a/include/waflz/waf.h
+++ b/include/waflz/waf.h
@@ -145,7 +145,7 @@ private:
         int32_t process_action_dx(const waflz_pb::sec_action_t &a_action, rqst_ctx &a_ctx);
         int32_t process_match(waflz_pb::event **ao_event, const waflz_pb::sec_rule_t &a_rule, rqst_ctx &a_ctx);
         int32_t compile(void);
-        int32_t set_defaults(bool& a_custom_rules);
+        int32_t set_defaults(bool a_custom_rules);
         // -------------------------------------------------
         // protobuf
         // -------------------------------------------------

--- a/include/waflz/waf.h
+++ b/include/waflz/waf.h
@@ -100,7 +100,7 @@ public:
         // -------------------------------------------------
         waf(engine &a_engine);
         ~waf();
-        int32_t process(waflz_pb::event **ao_event, void *a_ctx, rqst_ctx **ao_rqst_ctx = NULL);
+        int32_t process(waflz_pb::event **ao_event, void *a_ctx, rqst_ctx **ao_rqst_ctx = NULL, bool a_custom_rules = false);
         int32_t init(profile &a_profile);
         int32_t init(config_parser::format_t a_format, const std::string &a_path, bool a_apply_defaults = false, bool a_custom_rules = false);
         int32_t init(void* a_js, bool a_apply_defaults = false, bool a_custom_rules = false);

--- a/include/waflz/waf.h
+++ b/include/waflz/waf.h
@@ -102,8 +102,8 @@ public:
         ~waf();
         int32_t process(waflz_pb::event **ao_event, void *a_ctx, rqst_ctx **ao_rqst_ctx = NULL);
         int32_t init(profile &a_profile);
-        int32_t init(config_parser::format_t a_format, const std::string &a_path, bool a_apply_defaults = false);
-        int32_t init(void* a_js, bool a_apply_defaults = false);
+        int32_t init(config_parser::format_t a_format, const std::string &a_path, bool a_apply_defaults = false, bool a_custom_rules = false);
+        int32_t init(void* a_js, bool a_apply_defaults = false, bool a_custom_rules = false);
         int32_t get_str(std::string &ao_str, config_parser::format_t a_format);
         const char *get_err_msg(void) { return m_err_msg; }
         waflz_pb::sec_config_t* get_pb(void) { return m_pb; }
@@ -145,7 +145,7 @@ private:
         int32_t process_action_dx(const waflz_pb::sec_action_t &a_action, rqst_ctx &a_ctx);
         int32_t process_match(waflz_pb::event **ao_event, const waflz_pb::sec_rule_t &a_rule, rqst_ctx &a_ctx);
         int32_t compile(void);
-        int32_t set_defaults(void);
+        int32_t set_defaults(bool& a_custom_rules);
         // -------------------------------------------------
         // protobuf
         // -------------------------------------------------

--- a/src/core/rules.cc
+++ b/src/core/rules.cc
@@ -185,8 +185,8 @@ int32_t rules::process(waflz_pb::event **ao_event,
         {
                 l_rqst_ctx->set_body_max_len(m_waf->get_request_body_in_memory_limit());
         }
-        l_rqst_ctx->set_parse_xml(m_waf->get_parse_xml());
-        l_rqst_ctx->set_parse_json(m_waf->get_parse_json());
+        l_rqst_ctx->set_parse_xml(true);
+        l_rqst_ctx->set_parse_json(true);
 
         // -------------------------------------------------
         // run phase 1 init
@@ -202,7 +202,7 @@ int32_t rules::process(waflz_pb::event **ao_event,
         // -------------------------------------------------
         // process waf...
         // -------------------------------------------------
-        l_s = m_waf->process(&l_event, a_ctx, &l_rqst_ctx);
+        l_s = m_waf->process(&l_event, a_ctx, &l_rqst_ctx, true);
         if(l_s != WAFLZ_STATUS_OK)
         {
                 WAFLZ_PERROR(m_err_msg, "%s", m_waf->get_err_msg());

--- a/src/core/rules.cc
+++ b/src/core/rules.cc
@@ -90,7 +90,7 @@ int32_t rules::load_file(const char *a_buf, uint32_t a_buf_len)
         std::string l_p;
         l_p.assign(a_buf, a_buf_len);
         int32_t l_s;
-        l_s = m_waf->init(config_parser::JSON, l_p, true);
+        l_s = m_waf->init(config_parser::JSON, l_p, true, true);
         if(l_s != WAFLZ_STATUS_OK)
         {
                 WAFLZ_AERROR(m_err_msg, "error loading conf file-reason: %s",
@@ -128,7 +128,7 @@ int32_t rules::load(void* a_js)
         if(m_waf) { delete m_waf; m_waf = NULL; }
         m_waf = new waf(m_engine);
         int32_t l_s;
-        l_s = m_waf->init(a_js, true);
+        l_s = m_waf->init(a_js, true, true);
         if(l_s != WAFLZ_STATUS_OK)
         {
                 WAFLZ_AERROR(m_err_msg, "error loading conf file-reason: %s",
@@ -187,6 +187,7 @@ int32_t rules::process(waflz_pb::event **ao_event,
         }
         l_rqst_ctx->set_parse_xml(m_waf->get_parse_xml());
         l_rqst_ctx->set_parse_json(m_waf->get_parse_json());
+
         // -------------------------------------------------
         // run phase 1 init
         // -------------------------------------------------

--- a/src/core/waf.cc
+++ b/src/core/waf.cc
@@ -796,7 +796,7 @@ void set_var_tx(waflz_pb::sec_config_t &ao_conf_pb,
 //: \return:  TODO
 //: \param:   TODO
 //: ----------------------------------------------------------------------------
-int32_t waf::set_defaults(bool& a_custom_rules)
+int32_t waf::set_defaults(bool a_custom_rules)
 {
         ::waflz_pb::sec_config_t& l_conf_pb = *m_pb;
         // -------------------------------------------------

--- a/src/core/waf.cc
+++ b/src/core/waf.cc
@@ -609,7 +609,8 @@ int32_t waf::compile(void)
 //: ----------------------------------------------------------------------------
 int32_t waf::init(config_parser::format_t a_format,
                   const std::string &a_path,
-                  bool a_apply_defaults)
+                  bool a_apply_defaults,
+                  bool a_custom_rules)
 {
         // Check if already is initd
         if(m_is_initd)
@@ -629,7 +630,7 @@ int32_t waf::init(config_parser::format_t a_format,
         if(a_apply_defaults)
         {
                 m_pb = new waflz_pb::sec_config_t();
-                l_s = set_defaults();
+                l_s = set_defaults(a_custom_rules);
                 if(l_s != WAFLZ_STATUS_OK)
                 {
                         WAFLZ_PERROR(m_err_msg, "set_defaults failed");
@@ -691,7 +692,8 @@ int32_t waf::init(config_parser::format_t a_format,
 //: \param:   TODO
 //: ----------------------------------------------------------------------------
 int32_t waf::init(void* a_js,
-                  bool a_apply_defaults)
+                  bool a_apply_defaults,
+                  bool a_custom_rules)
 {
         // Check if already is initd
         if(m_is_initd)
@@ -711,7 +713,7 @@ int32_t waf::init(void* a_js,
         if(a_apply_defaults)
         {
                 m_pb = new waflz_pb::sec_config_t();
-                l_s = set_defaults();
+                l_s = set_defaults(a_custom_rules);
                 if(l_s != WAFLZ_STATUS_OK)
                 {
                         WAFLZ_PERROR(m_err_msg, "set_defaults failed");
@@ -794,7 +796,7 @@ void set_var_tx(waflz_pb::sec_config_t &ao_conf_pb,
 //: \return:  TODO
 //: \param:   TODO
 //: ----------------------------------------------------------------------------
-int32_t waf::set_defaults(void)
+int32_t waf::set_defaults(bool& a_custom_rules)
 {
         ::waflz_pb::sec_config_t& l_conf_pb = *m_pb;
         // -------------------------------------------------
@@ -808,7 +810,14 @@ int32_t waf::set_defaults(void)
         set_var_tx(l_conf_pb, "900002", "error_anomaly_score", "4");
         set_var_tx(l_conf_pb, "900003", "warning_anomaly_score", "3");
         set_var_tx(l_conf_pb, "900004", "notice_anomaly_score", "2");
-        set_var_tx(l_conf_pb, "900005", "anomaly_score", "0");
+        if(a_custom_rules)
+        {
+                set_var_tx(l_conf_pb, "900005", "anomaly_score", "1");
+        }
+        else
+        {
+                set_var_tx(l_conf_pb, "900005", "anomaly_score", "0");
+        }
         set_var_tx(l_conf_pb, "900006", "sql_injection_score", "0");
         set_var_tx(l_conf_pb, "900007", "xss_score", "0");
         set_var_tx(l_conf_pb, "900008", "inbound_anomaly_score", "0");
@@ -1854,6 +1863,7 @@ int32_t waf::process_action_nd(const waflz_pb::sec_action_t &a_action,
                         }
                         l_val_ref = &l_sv_val;
                 }
+
                 //------------------------------------------
                 // *****************************************
                 //               S C O P E

--- a/tests/data/waf/conf/rules/0050-ZrLf3KkQ.rules.json
+++ b/tests/data/waf/conf/rules/0050-ZrLf3KkQ.rules.json
@@ -9,14 +9,6 @@
           "msg": "Request Missing a Host Header",
           "phase": 2,
           "rev": "2",
-          "setvar": [
-            {
-              "op": "INCREMENT",
-              "scope": "TX",
-              "val": "%{tx.warning_anomaly_score}",
-              "var": "anomaly_score_pl1"
-            }
-          ],
           "severity": "4",
           "t": [
             "NONE"
@@ -54,14 +46,6 @@
           "msg": "Request User-Agent is monkeez",
           "phase": 2,
           "rev": "2",
-          "setvar": [
-            {
-              "op": "INCREMENT",
-              "scope": "TX",
-              "val": "%{tx.warning_anomaly_score}",
-              "var": "anomaly_score_pl1"
-            }
-          ],
           "severity": "4",
           "t": [
             "NONE"

--- a/tests/data/waf/conf/rules/0051-4fsYnj9c.rules.json
+++ b/tests/data/waf/conf/rules/0051-4fsYnj9c.rules.json
@@ -52,14 +52,14 @@
           "file": "0051-4fsYnj9c.rules",
           "id": "960008",
           "msg": "Request User-Agent is bananas",
-          "phase": 2,
+          "phase": 1,
           "rev": "2",
           "setvar": [
             {
-              "op": "INCREMENT",
               "scope": "TX",
-              "val": "%{tx.warning_anomaly_score}",
-              "var": "anomaly_score_pl1"
+              "var": "msg",
+              "op": "ASSIGN",
+              "val": "%{rule.msg}"
             }
           ],
           "severity": "4",

--- a/tests/data/waf/conf/rules/0051-4fsYnj9c.rules.json
+++ b/tests/data/waf/conf/rules/0051-4fsYnj9c.rules.json
@@ -9,14 +9,6 @@
           "msg": "Request Missing a Host Header",
           "phase": 2,
           "rev": "2",
-          "setvar": [
-            {
-              "op": "INCREMENT",
-              "scope": "TX",
-              "val": "%{tx.warning_anomaly_score}",
-              "var": "anomaly_score_pl1"
-            }
-          ],
           "severity": "4",
           "t": [
             "NONE"
@@ -54,14 +46,6 @@
           "msg": "Request User-Agent is bananas",
           "phase": 1,
           "rev": "2",
-          "setvar": [
-            {
-              "scope": "TX",
-              "var": "msg",
-              "op": "ASSIGN",
-              "val": "%{rule.msg}"
-            }
-          ],
           "severity": "4",
           "t": [
             "NONE"

--- a/tests/data/waf/conf/rules/0052-svUweMIX.rules.json
+++ b/tests/data/waf/conf/rules/0052-svUweMIX.rules.json
@@ -9,12 +9,6 @@
           "phase": 2,
           "setvar": [
             {
-              "op": "INCREMENT",
-              "scope": "TX",
-              "val": "%{tx.warning_anomaly_score}",
-              "var": "anomaly_score_pl1"
-            },
-            {
               "scope": "TX",
               "var": "msg",
               "op": "ASSIGN",

--- a/tests/data/waf/conf/rules/0052-svUweMIX.rules.json
+++ b/tests/data/waf/conf/rules/0052-svUweMIX.rules.json
@@ -4,17 +4,10 @@
     {
       "sec_rule": {
         "action": {
+          "action_type": "BLOCK",
           "id": "hY41qM7f",
           "msg": "Request User-Agent is ruletest",
           "phase": 2,
-          "setvar": [
-            {
-              "scope": "TX",
-              "var": "msg",
-              "op": "ASSIGN",
-              "val": "%{rule.msg}"
-            }
-          ],
           "t": [
             "LOWERCASE"
           ]


### PR DESCRIPTION
- Removing anomaly_threshold for custom rules. They will trigger an alert on a match and action_type:block
- No need for setvar in custom rules
- Custom rules events wont have any anomaly_score in logs
- Custom rules will parse xml and json by default