### PR TITLE
Fix request marking in scopes

### DIFF
--- a/src/core/scopes.cc
+++ b/src/core/scopes.cc
@@ -1151,8 +1151,13 @@ int32_t scopes::process(const waflz_pb::enforcement **ao_enf,
                         continue;
                 }
                 // -----------------------------------------
-                // process scope...
+                // process scope and mark request as analyzed
+                // for waf and rl. It doesnt matter whether
+                // a scope has rl or waf enabled, if it hits the
+                // scope, we will not double process it
                 // -----------------------------------------
+                (*ao_rqst_ctx)->m_waf_analyzed = true;
+                (*ao_rqst_ctx)->m_limit_analyzed = true;
                 l_s = process(ao_enf, ao_audit_event, ao_prod_event, l_sc, a_ctx, a_part_mk, ao_rqst_ctx);
                 if(l_s != WAFLZ_STATUS_OK)
                 {
@@ -1524,24 +1529,6 @@ int32_t scopes::process(const waflz_pb::enforcement** ao_enf,
         *ao_enf = NULL;
         *ao_audit_event = NULL;
         *ao_prod_event = NULL;
-        // -------------------------------------------------
-        // Mark rquest as analyzed by waf if either acl or
-        // waf profiles are present for this scope. Custom
-        // rules configs are not being considered here on
-        // purpose. This will allow using old instance
-        // format as well as new scopes + custom rules only
-        // -------------------------------------------------
-        (*ao_rqst_ctx)->m_waf_analyzed = ( a_scope.has__acl_audit__reserved() ||
-                           a_scope.has__profile_audit__reserved() ||
-                           a_scope.has__acl_prod__reserved() ||
-                           a_scope.has__profile_prod__reserved());
-        // -------------------------------------------------
-        // if scope has limit, mark it analyzed for limit/rl
-        // -------------------------------------------------
-        if(a_scope.limits_size())
-        {
-                (*ao_rqst_ctx)->m_limit_analyzed = true;
-        }
         // -------------------------------------------------
         // *************************************************
         //                   A U D I T


### PR DESCRIPTION
If request matches a scope, its marked for processing waf and rl