### PR TITLE
Optional file size limits

### DIFF
--- a/src/core/acl.cc
+++ b/src/core/acl.cc
@@ -1364,6 +1364,11 @@ int32_t acl::process_settings(waflz_pb::event **ao_event, rqst_ctx &a_ctx)
                 {
                         goto method_check;
                 }
+                if(!m_pb->has_max_file_size())
+                {
+                        // no max file size specified
+                        goto method_check;
+                }
                 if(l_cl < m_pb->max_file_size())
                 {
                         // file size within limits

--- a/src/core/profile.cc
+++ b/src/core/profile.cc
@@ -549,8 +549,6 @@ int32_t profile::validate(void)
         VERIFY_HAS(l_gs, arg_name_length);
         VERIFY_HAS(l_gs, arg_length);
         VERIFY_HAS(l_gs, total_arg_length);
-        VERIFY_HAS(l_gs, max_file_size);
-        VERIFY_HAS(l_gs, combined_file_sizes);
         VERIFY_HAS(l_gs, anomaly_threshold);
         // -------------------------------------------------
         // set resp header name

--- a/src/core/waf.cc
+++ b/src/core/waf.cc
@@ -1036,8 +1036,17 @@ int32_t waf::init(profile &a_profile)
         set_var_tx(l_conf_pb, "900016", "arg_name_length", to_string(l_gs.arg_name_length()));
         set_var_tx(l_conf_pb, "900017", "arg_length", to_string(l_gs.arg_length()));
         set_var_tx(l_conf_pb, "900018", "total_arg_length", to_string(l_gs.total_arg_length()));
-        set_var_tx(l_conf_pb, "900019", "max_file_size", to_string(l_gs.max_file_size()));
-        set_var_tx(l_conf_pb, "900020", "combined_file_sizes", to_string(l_gs.combined_file_sizes()));
+        // -------------------------------------------------
+        // add file sizes optionally
+        // -------------------------------------------------
+        if(l_gs.has_max_file_size())
+        {
+                set_var_tx(l_conf_pb, "900019", "max_file_size", to_string(l_gs.max_file_size()));
+        }
+        if(l_gs.has_combined_file_sizes())
+        {
+                set_var_tx(l_conf_pb, "900020", "combined_file_sizes", to_string(l_gs.combined_file_sizes()));
+        }
         // -------------------------------------------------
         // allowed http methods
         // -------------------------------------------------

--- a/tests/blackbox/profile/test_bb_profile.waf.prof.json
+++ b/tests/blackbox/profile/test_bb_profile.waf.prof.json
@@ -105,6 +105,7 @@
       "application/x-www-form-urlencoded",
       "multipart/form-data",
       "text/xml",
+      "text/html",
       "application/xml",
       "application/x-amf",
       "application/json"


### PR DESCRIPTION
## What
Make `combined_file_sizes` and `max_file_size` fields optional in profiles.  If they're not included remove `tx` var setting and verify can be omitted with test.

## How
Removed check for `VERIFY_HAS` in profile loading.  Added test to validate: a) file size check works b) if sizes are removed no check occurs.