### PR TITLE
remove strcpy() use in libinjection_sqli.c

### DIFF
--- a/ext/libinjection/src/libinjection.h
+++ b/ext/libinjection/src/libinjection.h
@@ -47,7 +47,7 @@ const char* libinjection_version(void);
  * \param[out] fingerprint buffer of 8+ characters.  c-string,
  * \return 1 if SQLi, 0 if benign.  fingerprint will be set or set to empty string.
  */
-int libinjection_sqli(const char* s, size_t slen, char fingerprint[]);
+int libinjection_sqli(const char* s, size_t slen, char fingerprint[], size_t fingerprint_len);
 
 /** ALPHA version of xss detector.
  *

--- a/ext/libinjection/src/libinjection_sqli.c
+++ b/ext/libinjection/src/libinjection_sqli.c
@@ -2309,7 +2309,7 @@ int libinjection_is_sqli(struct libinjection_sqli_state * sql_state)
     return FALSE;
 }
 
-int libinjection_sqli(const char* input, size_t slen, char fingerprint[])
+int libinjection_sqli(const char* input, size_t slen, char fingerprint[], size_t fingerprint_len)
 {
     int issqli;
     struct libinjection_sqli_state state;
@@ -2317,7 +2317,8 @@ int libinjection_sqli(const char* input, size_t slen, char fingerprint[])
     libinjection_sqli_init(&state, input, slen, 0);
     issqli = libinjection_is_sqli(&state);
     if (issqli) {
-        strcpy(fingerprint, state.fingerprint);
+        strncpy(fingerprint, state.fingerprint, fingerprint_len);
+        fingerprint[fingerprint_len - 1] = 0;
     } else {
         fingerprint[0] = '\0';
     }

--- a/src/core/op.cc
+++ b/src/core/op.cc
@@ -1085,7 +1085,7 @@ OP(DETECTSQLI)
         }
         char l_fprnt[8];
         int32_t l_match = 0;
-        l_match = libinjection_sqli(a_buf, a_len, l_fprnt);
+        l_match = libinjection_sqli(a_buf, a_len, l_fprnt, sizeof(l_fprnt));
         if(l_match)
         {
                 ao_match = true;


### PR DESCRIPTION
The use of strcpy() is flagged as a security risk by a code scanner.