### PR TITLE
setting libxml2 generic error function to do nothing to disable error…

### DIFF
--- a/src/core/engine.cc
+++ b/src/core/engine.cc
@@ -27,6 +27,17 @@
 #include <libxml/parser.h>
 namespace ns_waflz {
 //! ----------------------------------------------------------------------------
+//! statics
+//! ----------------------------------------------------------------------------
+//! ----------------------------------------------------------------------------
+//! \details define error function for libxml2 to "| > /dev/null" errors
+//!          defined w/ xmlGenericErrorFunc function sig
+//! \return  NA
+//! ----------------------------------------------------------------------------
+static void xml_error_func(void *ctx, const char *msg, ...)
+{
+}
+//! ----------------------------------------------------------------------------
 //! \details TODO
 //! \return  TODO
 //! \param   TODO
@@ -181,6 +192,8 @@ int32_t engine::init()
         //             xml initialization
         // *************************************************
         // -------------------------------------------------
+        xmlGenericErrorFunc l_err_h = (xmlGenericErrorFunc)xml_error_func;
+        initGenericErrorDefaultFunc(&l_err_h);
         xmlInitParser();
         // -------------------------------------------------
         // *************************************************


### PR DESCRIPTION
### What
Override xml error handler to do nothing to silence output like:
```sh
body.xml:1: parser error : Failure to process entity xxe
 foo ANY >        <!ENTITY xxe SYSTEM "file:///etc/passwd" >]>        <foo>&xxe;
                                                                               ^
body.xml:1: parser error : Entity 'xxe' not defined
 foo ANY >        <!ENTITY xxe SYSTEM "file:///etc/passwd" >]>        <foo>&xxe;
                                                                               ^
```

Tested with payload
```xml
<?xml version="1.0" encoding="ISO-8859-1"?>
        <!DOCTYPE foo [
        <!ELEMENT foo ANY >
        <!ENTITY xxe SYSTEM "file:///etc/passwd" >]>
        <foo>&xxe;</foo>
```

^Thx to @at1984z for the fix!

