### PR TITLE
install string_util.h file_util.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -215,6 +215,7 @@ SET(HDRS
     ${CMAKE_SOURCE_DIR}/include/waflz/trace.h
     ${CMAKE_SOURCE_DIR}/include/waflz/waf.h
     ${CMAKE_SOURCE_DIR}/include/waflz/waflz.h
+    ${CMAKE_SOURCE_DIR}/include/waflz/string_util.h
     # ------------------------------------------------------
     # db
     # ------------------------------------------------------
@@ -237,6 +238,10 @@ SET(HDRS
     ${CMAKE_BINARY_DIR}/proto/request_info.pb.h
     ${CMAKE_BINARY_DIR}/proto/rule.pb.h
     ${CMAKE_BINARY_DIR}/proto/scope.pb.h
+    # ------------------------------------------------------
+    # support
+    # ------------------------------------------------------
+    ${CMAKE_SOURCE_DIR}/src/support/file_util.h
 )
 if(BUILD_REDIS)
   list(APPEND HDRS


### PR DESCRIPTION
`include/waflz/string_util.h` is included from `def.h`.

`src/support/file_util.h` provides ns_waflz::read_file() that is needed for clients that manage profiles on their own:

```
    char *l_buf;
    uint32_t l_buf_len;

    auto l_s = ns_waflz::read_file(profile_file_name, &l_buf, l_buf_len);

    auto profile = new ns_waflz::profile(engine);

    l_s = profile->load(l_buf, l_buf_len);
```
