### PR TITLE
Unobfuscate wjc errors

### DIFF
--- a/src/core/engine.cc
+++ b/src/core/engine.cc
@@ -471,7 +471,8 @@ int32_t engine::compile(compiled_config_t &ao_cx_cfg,
                                 l_s = create_nms_from_file(&l_nms, l_f_path);
                                 if(l_s != WAFLZ_STATUS_OK)
                                 {
-                                        WAFLZ_PERROR(m_err_msg, "Failed to create nms from file %s", l_rule->operator_().value().c_str());
+                                        WAFLZ_PERROR(m_err_msg, "Failed to create nms from file %s %s", 
+							l_rule->operator_().value().c_str(), strerror(errno));
                                         return WAFLZ_STATUS_ERROR;
                                 }
                                 ao_cx_cfg.m_nms_list.push_back(l_nms);
@@ -488,7 +489,8 @@ int32_t engine::compile(compiled_config_t &ao_cx_cfg,
                                 l_s = create_ac_from_str(&l_ac, l_rule->operator_().value());
                                 if(l_s != WAFLZ_STATUS_OK)
                                 {
-                                        WAFLZ_PERROR(m_err_msg, "Failed to create ac from string %s", l_rule->operator_().value().c_str());
+                                        WAFLZ_PERROR(m_err_msg, "Failed to create ac from string %s %s", 
+							l_rule->operator_().value().c_str(), strerror(errno));
                                         return WAFLZ_STATUS_ERROR;
                                 }
                                 ao_cx_cfg.m_ac_list.push_back(l_ac);
@@ -508,7 +510,8 @@ int32_t engine::compile(compiled_config_t &ao_cx_cfg,
                                 l_s = create_ac_from_file(&l_ac, l_f_path);
                                 if(l_s != WAFLZ_STATUS_OK)
                                 {
-                                        WAFLZ_PERROR(m_err_msg, "Failed to create ac from file %s", l_rule->operator_().value().c_str());
+                                        WAFLZ_PERROR(m_err_msg, "Failed to create ac from file %s %s", 
+							l_rule->operator_().value().c_str(), strerror(errno));
                                         return WAFLZ_STATUS_ERROR;
                                 }
                                 ao_cx_cfg.m_ac_list.push_back(l_ac);

--- a/src/core/engine.cc
+++ b/src/core/engine.cc
@@ -204,7 +204,7 @@ int32_t engine::init()
         l_s = m_geoip2_mmdb->init(m_geoip2_db, m_geoip2_isp_db);
         if(l_s != WAFLZ_STATUS_OK)
         {
-                 WAFLZ_PERROR(m_err_msg,"error intialiting");
+                 WAFLZ_PERROR(m_err_msg,"error intializing");
                  return WAFLZ_STATUS_OK;
         }
         return WAFLZ_STATUS_OK;

--- a/src/core/waf.cc
+++ b/src/core/waf.cc
@@ -750,7 +750,6 @@ int32_t waf::init(config_parser::format_t a_format,
         l_s = compile();
         if(l_s != WAFLZ_STATUS_OK)
         {
-                WAFLZ_PERROR(m_err_msg, "compilation failed");
                 return WAFLZ_STATUS_ERROR;
         }
         m_is_initd = true;


### PR DESCRIPTION
`WAFLZ_PERROR(m_err_msg, "compilation failed");` was suppressing error messages from init. 
also added strerror print to some of the relevant errors.