### PR TITLE
dont copy CMakeCache.txt into new docker ecosystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && \
 
 COPY . /opt/waflz
 
+RUN find /opt/waflz -name "CMakeCache.txt" -exec rm {} \;
+
 RUN cd /opt/waflz && \
      pip3 install -r requirements.txt && \
      ./build.sh


### PR DESCRIPTION
- copying CMakeCache.txt will cause the build to fail
  - remove CMakeCache.txt in docker image before building waflz
  - example error below
```
CMake Error: The current CMakeCache.txt directory /opt/waflz/build/CMakeCache.txt is different than the directory /home/rmintz87/gitlab/waflz/build where CMakeCache.txt was created. This may result in binaries being created in the wrong place. If you are not sure, reedit the CMakeCache.txt
CMake Error: The source "/opt/waflz/CMakeLists.txt" does not match the source "/home/$USER/gitlab/waflz/CMakeLists.txt" used to generate cache.  Re-run cmake with a different source directory.

```