### PR TITLE
test enabling https by default for is2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ endif()
 include(ExternalProject)
 if(BUILD_APPS)
   ExternalProject_Add(submodule_is2
+    CMAKE_ARGS -DBUILD_TLS=ON
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/sub/is2
     INSTALL_COMMAND ""
   )


### PR DESCRIPTION
### What
To support `proxy` mode for `waflz_server` with upstream hosts that are `https://`, enable building [is2[(https://github.com/EdgeCast/is2), with `BUILD_TLS=ON` enabled by default.