### PR TITLE
fixing memchr usage in unused function.

### DIFF
--- a/src/op/nms.cc
+++ b/src/op/nms.cc
@@ -191,7 +191,7 @@ nms::addr_t nms::detect_addr(const char *a_buf, uint32_t a_buf_len)
 {
         nms::addr_t l_addr = nms::ADDR_NONE;
         int l_s;
-        if(memchr(a_buf, a_buf_len, ':') == NULL)
+        if(memchr(a_buf, ':', a_buf_len) == NULL)
         {
                 struct in_addr l_in;
                 l_s = inet_pton(AF_INET, a_buf, &l_in);


### PR DESCRIPTION
### What
- Fixing usage of `memchr` -placing args in proper order.
- Usage is part of unused function to detect address types for an address string (`detect_addr`) using `inet_pton`, but a simpler check for `:` is currently used, so not a high priority fix.
