### PR TITLE
add option BUILD_CUSTOM_CAPLENMAX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(BUILD_REDIS          "Build support for redis" OFF)
 option(BUILD_UBUNTU         "Build for Ubuntu" OFF)
 option(BUILD_CUSTOM_OPENSSL "Build for openssl" OFF)
 option(BUILD_REDHAT         "Build for Red Hat" OFF)
+option(BUILD_CUSTOM_CAPLENMAX  "Build with custom CAP_LEN maximum" OFF)
 # ------------------------------------------------------------------------------
 # Add the corrent -std flag, whatever it is
 # ------------------------------------------------------------------------------
@@ -70,6 +71,7 @@ message("    Build support for redis:                   " "BUILD_REDIS          
 message("    Build for Ubuntu (adds package help):      " "BUILD_UBUNTU            " ${BUILD_UBUNTU})
 message("    Build for custom OpenSSL:                  " "BUILD_CUSTOM_OPENSSL    " ${BUILD_CUSTOM_OPENSSL})
 message("    Build for Red Hat:                         " "BUILD_REDHAT            " ${BUILD_REDHAT})
+message("    Build with custom CAP_LEN maximum:         " "BUILD_CUSTOM_CAPLENMAX  " ${BUILD_CUSTOM_CAPLENMAX})
 message("")
 # ------------------------------------------------------------------------------
 # Fortify Options
@@ -109,6 +111,14 @@ endif()
 if(BUILD_REDHAT)
   set(LIBRARIES ${LIBRARIES} ssl crypto pcre protobuf xml2)
   add_definitions(-DWAFLZ_PCRE_INFO_FLAGS_MISSING)
+endif()
+# ------------------------------------------------------------------------------
+# special build case for CUSTOM_CAPLENMAX
+# ------------------------------------------------------------------------------
+if(BUILD_CUSTOM_CAPLENMAX)
+  add_definitions(-DWAFLZ_CUSTOM_CAPLENMAX=${BUILD_CUSTOM_CAPLENMAX})
+else()
+  add_definitions(-DWAFLZ_CUSTOM_CAPLENMAX=1024)
 endif()
 # ------------------------------------------------------------------------------
 # Mac OS X

--- a/src/core/waf.cc
+++ b/src/core/waf.cc
@@ -2318,7 +2318,7 @@ int32_t waf::process_match(waflz_pb::event** ao_event,
         // intercept status
         // -------------------------------------------------
         l_sub_event->set_rule_intercept_status(HTTP_STATUS_FORBIDDEN);
-#define CAP_LEN(_len) (_len > 1024 ? 1024: _len)
+#define CAP_LEN(_len) (_len > WAFLZ_CUSTOM_CAPLENMAX ? WAFLZ_CUSTOM_CAPLENMAX: _len)
         waflz_pb::event::var_t* l_m_var = NULL;
         // -------------------------------------------------
         // matched var


### PR DESCRIPTION
Proposed option BUILD_CUSTOM_CAPLENMAX is an unsigned integer that allows to modify the maximum value of inspected buffer, e.g. matched variable, as encoded in macro `CAP_LEN()` in `src/core/waf.cc`.

The current hardcoded maximum is 1024.

This PR keeps 1024 as the default option value.